### PR TITLE
Fix TextParsable instance for UTCTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-enum-text.cabal
 /dist
 /dist-newstyle
 ._*

--- a/enum-text.cabal
+++ b/enum-text.cabal
@@ -1,0 +1,73 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           enum-text
+version:        0.5.2.1
+synopsis:       A text rendering and parsing toolkit for enumerated types
+description:    A text rendering and parsing toolkit for enumerated types. Please see the README on GitHub at <https://github.com/cdornan/enum-text#readme>
+category:       Text
+homepage:       https://github.com/cdornan/enum-text#readme
+bug-reports:    https://github.com/cdornan/enum-text/issues
+author:         Chris Dornan
+maintainer:     chris@chrisdornan.com
+copyright:      2019 Chris Dornan
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/cdornan/enum-text
+
+library
+  exposed-modules:
+      Text.Enum.Text
+  other-modules:
+      Paths_enum_text
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      array
+    , attoparsec
+    , base >=4.9 && <10
+    , bytestring
+    , fmt
+    , hashable
+    , possibly
+    , scientific
+    , text
+    , time
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite my-package-test
+  type: exitcode-stdio-1.0
+  main-is: Doctest.hs
+  other-modules:
+      Paths_enum_text
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      array
+    , attoparsec
+    , base >=4.9 && <10
+    , bytestring
+    , doctest
+    , doctest-discover
+    , enum-text
+    , fmt
+    , hashable
+    , possibly
+    , scientific
+    , text
+    , time
+    , unordered-containers
+  default-language: Haskell2010

--- a/enum-text.cabal
+++ b/enum-text.cabal
@@ -47,7 +47,7 @@ library
     , unordered-containers
   default-language: Haskell2010
 
-test-suite my-package-test
+test-suite enum-text-tests
   type: exitcode-stdio-1.0
   main-is: Doctest.hs
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -18,10 +18,12 @@ description:        A text rendering and parsing toolkit for enumerated types.
 dependencies:
 - base >= 4.9 && < 10
 - array
+- attoparsec
 - bytestring
 - fmt
 - hashable
 - possibly
+- scientific
 - text
 - time
 - unordered-containers
@@ -31,3 +33,16 @@ ghc-options:
 
 library:
   source-dirs: src
+
+tests:
+  my-package-test:
+    main:                Doctest.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - doctest
+    - doctest-discover
+    - enum-text

--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,7 @@ library:
   source-dirs: src
 
 tests:
-  my-package-test:
+  enum-text-tests:
     main:                Doctest.hs
     source-dirs:         test
     ghc-options:

--- a/src/Text/Enum/Text.hs
+++ b/src/Text/Enum/Text.hs
@@ -238,8 +238,15 @@ parseTextRead :: Read a
               => String   -- ^ name of type bing parsed (for failure message)
               -> T.Text   -- ^ 'T.Text' to be parsed
               -> Possibly a
-parseTextRead ty_s txt =
-    maybe (Left $ typeError ty_s $ show str) Right $ readMaybe str
+parseTextRead = parseTextUsing (readMaybe . T.unpack)
+
+-- | Use the given function to turn the input string into a 'TextParsable'
+parseTextUsing :: (T.Text -> Maybe a)
+               -> String   -- ^ name of type bing parsed (for failure message)
+               -> T.Text   -- ^ 'T.Text' to be parsed
+               -> Possibly a
+parseTextUsing maybeParser ty_s txt =
+    maybe (Left $ typeError ty_s $ show str) Right $ maybeParser txt
   where
     str = T.unpack txt
 

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF doctest-discover -optF test/doctest-config.json #-}

--- a/test/doctest-config.json
+++ b/test/doctest-config.json
@@ -1,0 +1,3 @@
+{
+    "doctestOptions": ["-XTypeApplications", "-XOverloadedStrings"]
+}


### PR DESCRIPTION
Fixes #1.

@cdornan I have taken the liberty at attempting a fix, I hope you don't mind 😉 I have also added some very lightweight testing via `doctest`, at least to check the regression with `UTCTime` has been fixed.

I have also exposed the `.cabal` file for ease of integration with downstream packages.

Let me know what you think!